### PR TITLE
图片较小时不居中

### DIFF
--- a/source/css/reset.css
+++ b/source/css/reset.css
@@ -51,6 +51,7 @@ picture
     width: auto;
     max-width: 100%;
     display: block;
+    margin: 0 auto;
 }
 
 input,


### PR DESCRIPTION
图片不居中看起来有点不协调，尝试更改了一下，希望作者考虑merge

修改前：（修改了图片宽度，模拟宽度较小的情况）
<img width="1472" alt="Screen Shot 2022-07-10 at 01 07 30" src="https://user-images.githubusercontent.com/32984161/178115900-de5b9b3b-1f50-4540-887d-b4c4aec9bcac.png">

修改后：
<img width="1472" alt="Screen Shot 2022-07-10 at 01 07 44" src="https://user-images.githubusercontent.com/32984161/178115908-e8223a35-0d37-4d70-9eb5-0d7e12387cbb.png">

